### PR TITLE
Dataset#nearest_neighbors

### DIFF
--- a/lib/sequel/plugins/pgvector.rb
+++ b/lib/sequel/plugins/pgvector.rb
@@ -35,7 +35,9 @@ module Sequel
               order
             end
 
-          select_append(Sequel.lit("#{neighbor_distance} AS neighbor_distance", value)).exclude(column => nil).order(Sequel.lit(order, value))
+          select_append(Sequel.lit("#{neighbor_distance} AS neighbor_distance", value))
+            .exclude(column => nil)
+            .order(Sequel.lit(order, value))
         end
 
         def vector_columns
@@ -57,7 +59,9 @@ module Sequel
           # important! check if neighbor attribute before calling send
           raise ArgumentError, "Invalid column" unless self.class.vector_columns[column]
 
-          self.class.nearest_neighbors(column, self[column], **options).exclude(primary_key => self[primary_key])
+          self.class
+            .nearest_neighbors(column, self[column], **options)
+            .exclude(primary_key => self[primary_key])
         end
 
         def []=(k, v)

--- a/test/sequel_test.rb
+++ b/test/sequel_test.rb
@@ -38,6 +38,10 @@ class TestSequel < Minitest::Test
     results = Item.first.nearest_neighbors(:embedding, distance: "euclidean").limit(5)
     assert_equal [[1, 1, 2], [2, 2, 2]], results.map(&:embedding)
     assert_equal [1, Math.sqrt(3)], results.map { |r| r[:neighbor_distance] }
+
+    sampled_item = Item.order(Sequel.function(:random)).first
+    results = Item.where(id: sampled_item.id).nearest_neighbors(:embedding, [1,1,1], distance: "euclidean").limit(1)
+    assert_equal [sampled_item.embedding], results.map(&:embedding)
   end
 
   def items


### PR DESCRIPTION
# Motivation

To be able to chain other predicates w/ the nearest_neighbors call, e.g.

```ruby
Model.where(...).nearest_neighbors(...)
```

# Supporting documentation

https://sequel.jeremyevans.net/rdoc/files/doc/model_plugins_rdoc.html#label-Making+Dataset+Methods+Callable+as+Class+Methods