### PR TITLE
Add support for nullable vector columns

### DIFF
--- a/lib/pgvector.rb
+++ b/lib/pgvector.rb
@@ -9,6 +9,8 @@ module Pgvector
   autoload :PG, "pgvector/pg"
 
   def self.encode(data)
+    return nil if data.nil?
+
     if data.is_a?(Vector) || data.is_a?(HalfVector) || data.is_a?(SparseVector)
       data.to_s
     else
@@ -17,6 +19,8 @@ module Pgvector
   end
 
   def self.decode(string)
+    return nil if string.nil?
+
     if string[0] == "["
       Vector.from_text(string).to_a
     elsif string[0] == "{"

--- a/lib/sequel/plugins/pgvector.rb
+++ b/lib/sequel/plugins/pgvector.rb
@@ -76,8 +76,11 @@ module Sequel
 
         def [](k)
           if self.class.vector_columns.key?(k.to_sym)
+            value = super
+            return nil if value.nil?
+
             # to_s needed for JRuby
-            ::Pgvector.decode(super.to_s)
+            ::Pgvector.decode(value.to_s)
           else
             super
           end

--- a/test/pgvector_test.rb
+++ b/test/pgvector_test.rb
@@ -24,4 +24,12 @@ class PgvectorTest < Minitest::Test
   def test_decode_sparse_vector
     assert_equal [1, 0, 2, 0, 3, 0], Pgvector.decode("{1:1.0,3:2.0,5:3.0}/6").to_a
   end
+
+  def test_encode_nil
+    assert_nil Pgvector.encode(nil)
+  end
+
+  def test_decode_nil
+    assert_nil Pgvector.decode(nil)
+  end
 end

--- a/test/sequel_test.rb
+++ b/test/sequel_test.rb
@@ -153,6 +153,19 @@ class TestSequel < Minitest::Test
     assert_equal [1, Math.sqrt(3)], results.map { |r| r[:neighbor_distance] }
   end
 
+  def test_nil_embedding
+    item = Item.create(id: 4)
+    item.refresh
+    assert_nil item.embedding
+  end
+
+  def test_set_nil_embedding
+    item = Item.create(id: 4, embedding: [1, 1, 1])
+    item.update(embedding: nil)
+    item.refresh
+    assert_nil item.embedding
+  end
+
   def test_model_dataset
     create_items
     sampled_item = Item.order(Sequel.function(:random)).first


### PR DESCRIPTION
Hi @ankane,

Looks like the gem doesn't handle nil values gracefully. I created this small script to demostrate the issues I found:

```ruby
# frozen_string_literal: true

require "bundler/setup"
require "sequel"
require "pgvector"

DB = Sequel.connect("postgres://localhost/pgvector_ruby_test")
DB.run("CREATE EXTENSION IF NOT EXISTS vector")

DB.drop_table? :items
DB.create_table :items do
  primary_key :id
  column :embedding, "vector(3)"
end

# Sequel models
class Item < Sequel::Model(DB[:items])
  plugin :pgvector, :embedding
end

item_1 = Item.create(embedding: [1.0, 2.0, 3.0])
item_2 = Item.create

puts "✅ Item 1 embedding: #{item_1.embedding.inspect}"
puts "✅ Item 2 embedding: #{item_2.embedding.inspect}"

begin
  Item.create(embedding: nil) # ERROR: vector must have at least 1 dimension (PG::DataException)
rescue Sequel::DatabaseError => e
  puts "❌ Error inserting item with nil embedding: #{e.message}"
end

# Pgvector directly
begin
  Pgvector.decode(nil)  # => NoMethodError if embedding is NULL
rescue NoMethodError => e
    puts "❌ Error decoding nil embedding: #{e.message}"
end
```

I made some changes to support nil values but I'm not sure if this is the correct approach, maybe defining an empty string as default value for vector columns is just enough.

Feel free to close this Pull Request if the solution is not what you'd expect.
